### PR TITLE
fix images saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /log/*
 !/log/.keep
 /tmp
+public/system

--- a/app/controllers/cabbages_controller.rb
+++ b/app/controllers/cabbages_controller.rb
@@ -54,6 +54,6 @@ class CabbagesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def cabbage_params
-      params.require(:cabbage).permit(:name, :content)
+      params.require(:cabbage).permit(:name, :content, :image)
     end
 end


### PR DESCRIPTION
Images haven't been saved because :image attr hasn't been permitted (in `cabbage_params` method). Fixed that. Also add `public/system` to `.gitignore` to not store uploaded images in git.
